### PR TITLE
Add logout API method

### DIFF
--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -286,10 +286,7 @@ class SagemcomClient:
 
     async def logout(self):
         """Log out of the Sagemcom F@st device."""
-        actions = {
-            "id": 0,
-            "method": "logOut"
-        }
+        actions = {"id": 0, "method": "logOut"}
 
         await self.__api_request_async([actions], False)
 

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -289,6 +289,7 @@ class SagemcomClient:
             raise UnauthorizedException(data)
 
     async def logout(self):
+        """Log out of the Sagemcom F@st device."""
         actions = {
             "id": 0,
             "method": "logOut"

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -293,9 +293,7 @@ class SagemcomClient:
             "id": 0,
             "method": "logOut"
         }
-
-        response = await self.__api_request_async([actions], True)
-        data = self.__get_response(response)
+        await self.__api_request_async([actions], False)
 
     async def get_value_by_xpath(
         self, xpath: str, options: Optional[Dict] = {}

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -173,7 +173,7 @@ class SagemcomClient:
     async def __api_request_async(self, actions, priority=False):
         """Build request to the internal JSON-req API."""
         # Auto login
-        if self._server_nonce == "" and actions[0]["method"] != "logIn":
+        if self._server_nonce == "" and actions[0]["method"] != "logIn" and actions[0]["method"] != "logOut":
             await self.login()
 
         self.__generate_request_id()

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -288,6 +288,15 @@ class SagemcomClient:
         else:
             raise UnauthorizedException(data)
 
+    async def logout(self):
+        actions = {
+            "id": 0,
+            "method": "logOut"
+        }
+
+        response = await self.__api_request_async([actions], True)
+        data = self.__get_response(response)
+
     async def get_value_by_xpath(
         self, xpath: str, options: Optional[Dict] = {}
     ) -> Dict:

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -172,10 +172,6 @@ class SagemcomClient:
 
     async def __api_request_async(self, actions, priority=False):
         """Build request to the internal JSON-req API."""
-        # Auto login
-        if self._server_nonce == "" and actions[0]["method"] != "logIn" and actions[0]["method"] != "logOut":
-            await self.login()
-
         self.__generate_request_id()
         self.__generate_nonce()
         self.__generate_auth_key()

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -294,7 +294,12 @@ class SagemcomClient:
             "id": 0,
             "method": "logOut"
         }
+
         await self.__api_request_async([actions], False)
+
+        self._session_id = -1
+        self._server_nonce = ""
+        self._request_id = -1
 
     async def get_value_by_xpath(
         self, xpath: str, options: Optional[Dict] = {}
@@ -336,7 +341,6 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([actions], False)
-        print(response)
 
         return response
 


### PR DESCRIPTION
While running the [Getting Started](https://github.com/iMicknl/python-sagemcom-api#getting-started) example, the KPN Box 12 keeps returning XMO_MAX_SESSION_COUNT_ERR errors. 
This is simply fixed by adding a logout API method and calling this in a try / finally block.
