### PR TITLE
Implement get_device_info for F5359 used by KPN Box 12

### DIFF
--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -173,7 +173,7 @@ class SagemcomClient:
     async def __api_request_async(self, actions, priority=False):
         """Build request to the internal JSON-req API."""
         # Auto login
-        if self._server_nonce == "" and actions[0]["method"] != "logIn":
+        if self._server_nonce == "" and actions[0]["method"] != "logIn" and actions[0]["method"] != "logOut":
             await self.login()
 
         self.__generate_request_id()
@@ -288,6 +288,19 @@ class SagemcomClient:
         else:
             raise UnauthorizedException(data)
 
+    async def logout(self):
+        """Log out of the Sagemcom F@st device."""
+        actions = {
+            "id": 0,
+            "method": "logOut"
+        }
+
+        await self.__api_request_async([actions], False)
+
+        self._session_id = -1
+        self._server_nonce = ""
+        self._request_id = -1
+
     async def get_value_by_xpath(
         self, xpath: str, options: Optional[Dict] = {}
     ) -> Dict:
@@ -328,7 +341,6 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([actions], False)
-        print(response)
 
         return response
 
@@ -340,6 +352,7 @@ class SagemcomClient:
         except UnknownPathException:
             device_info = DeviceInfo()
             device_info.mac_address = await self.get_value_by_xpath("Device/DeviceInfo/MACAddress")
+            device_info.manufacturer = "Sagemcom"
             device_info.model_name = await self.get_value_by_xpath("Device/DeviceInfo/ModelNumber")
             device_info.model_number = await self.get_value_by_xpath("Device/DeviceInfo/ProductClass")
             device_info.product_class = await self.get_value_by_xpath("Device/DeviceInfo/ProductClass")

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -286,10 +286,7 @@ class SagemcomClient:
 
     async def logout(self):
         """Log out of the Sagemcom F@st device."""
-        actions = {
-            "id": 0,
-            "method": "logOut"
-        }
+        actions = {"id": 0, "method": "logOut"}
 
         await self.__api_request_async([actions], False)
 
@@ -347,13 +344,25 @@ class SagemcomClient:
             return DeviceInfo(**data.get("device_info"))
         except UnknownPathException:
             device_info = DeviceInfo()
-            device_info.mac_address = await self.get_value_by_xpath("Device/DeviceInfo/MACAddress")
+            device_info.mac_address = await self.get_value_by_xpath(
+                "Device/DeviceInfo/MACAddress"
+            )
             device_info.manufacturer = "Sagemcom"
-            device_info.model_name = await self.get_value_by_xpath("Device/DeviceInfo/ModelNumber")
-            device_info.model_number = await self.get_value_by_xpath("Device/DeviceInfo/ProductClass")
-            device_info.product_class = await self.get_value_by_xpath("Device/DeviceInfo/ProductClass")
-            device_info.serial_number = await self.get_value_by_xpath("Device/DeviceInfo/SerialNumber")
-            device_info.software_version = await self.get_value_by_xpath("Device/DeviceInfo/SoftwareVersion")
+            device_info.model_name = await self.get_value_by_xpath(
+                "Device/DeviceInfo/ModelNumber"
+            )
+            device_info.model_number = await self.get_value_by_xpath(
+                "Device/DeviceInfo/ProductClass"
+            )
+            device_info.product_class = await self.get_value_by_xpath(
+                "Device/DeviceInfo/ProductClass"
+            )
+            device_info.serial_number = await self.get_value_by_xpath(
+                "Device/DeviceInfo/SerialNumber"
+            )
+            device_info.software_version = await self.get_value_by_xpath(
+                "Device/DeviceInfo/SoftwareVersion"
+            )
             return device_info
 
     async def get_hosts(self, only_active: Optional[bool] = False) -> List[Device]:

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -172,10 +172,6 @@ class SagemcomClient:
 
     async def __api_request_async(self, actions, priority=False):
         """Build request to the internal JSON-req API."""
-        # Auto login
-        if self._server_nonce == "" and actions[0]["method"] != "logIn" and actions[0]["method"] != "logOut":
-            await self.login()
-
         self.__generate_request_id()
         self.__generate_nonce()
         self.__generate_auth_key()

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -334,9 +334,18 @@ class SagemcomClient:
 
     async def get_device_info(self) -> DeviceInfo:
         """Retrieve information about Sagemcom F@st device."""
-        data = await self.get_value_by_xpath("Device/DeviceInfo")
-
-        return DeviceInfo(**data.get("device_info"))
+        try:
+            data = await self.get_value_by_xpath("Device/DeviceInfo")
+            return DeviceInfo(**data.get("device_info"))
+        except UnknownPathException:
+            device_info = DeviceInfo()
+            device_info.mac_address = await self.get_value_by_xpath("Device/DeviceInfo/MACAddress")
+            device_info.model_name = await self.get_value_by_xpath("Device/DeviceInfo/ModelNumber")
+            device_info.model_number = await self.get_value_by_xpath("Device/DeviceInfo/ProductClass")
+            device_info.product_class = await self.get_value_by_xpath("Device/DeviceInfo/ProductClass")
+            device_info.serial_number = await self.get_value_by_xpath("Device/DeviceInfo/SerialNumber")
+            device_info.software_version = await self.get_value_by_xpath("Device/DeviceInfo/SoftwareVersion")
+            return device_info
 
     async def get_hosts(self, only_active: Optional[bool] = False) -> List[Device]:
         """Retrieve hosts connected to Sagemcom F@st device."""


### PR DESCRIPTION
Getting the value for Path `Device/DeviceInfo` triggers the `UnknownPathException` on a F5359 device.
The required information is available via individual requests, though.
