### PR TITLE
Fixed the problem I described in issue #183

### DIFF
--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -349,7 +349,7 @@ class SagemcomClient:
         actions = {
             "id": 0,
             "method": "setValue",
-            "xpath": xpath,
+            "xpath": urllib.parse.quote(xpath),
             "parameters": {"value": str(value)},
             "options": options,
         }


### PR DESCRIPTION
The xpath in set_value_by_xpath is now also url encoded.
Now requests with selectors (e.g. "some/xpath[Key='Value']") are possible without "Invalid format" errors.
For more details see issue #183.