### PR TITLE
5290 from Frontier

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The Sagemcom F@st series is used by multiple cable companies, where some cable c
 | Sagemcom F@st 4353    | Belong Gateway       | md5                   | username: admin, password: "" |
 | Sagemcom F@st 5250    | Bell (Home Hub 2000) | md5                   | username: guest, password: "" |
 | Sagemcom F@st 5280    |                      | sha512                |                               |
+| Sagemcom F@st 5290    | Frontier             | md5                   | username: admin               |
 | Sagemcom F@st 5359    | KPN (Box 12)         | sha512                | username: admin               |
 | Sagemcom F@st 5364    | BT (Smart Hub)       | md5                   | username: guest, password: "" |
 | SagemCom F@st 5366SD  | Eir F3000            | md5                   |                               |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Sagemcom F@st series is used by multiple cable companies, where some cable c
 | Sagemcom F@st 4353    | Belong Gateway       | md5                   | username: admin, password: "" |
 | Sagemcom F@st 5250    | Bell (Home Hub 2000) | md5                   | username: guest, password: "" |
 | Sagemcom F@st 5280    |                      | sha512                |                               |
-| Sagemcom F@st 5290    | Frontier             | md5                   | username: admin               |
+| Sagemcom F@st 5290 / FWR226e    | Frontier             | md5                   | username: admin               |
 | Sagemcom F@st 5359    | KPN (Box 12)         | sha512                | username: admin               |
 | Sagemcom F@st 5364    | BT (Smart Hub)       | md5                   | username: guest, password: "" |
 | SagemCom F@st 5366SD  | Eir F3000            | md5                   |                               |


### PR DESCRIPTION
I have a 5290 from https://frontier.com/ in Tampa, Florida, USA. I had to set `ENCRYPTION_METHOD = EncryptionMethod.MD5` in the example. It does require a password, the default password is written on the box.

Here is some of the device_info:
```
manufacturer='Sagemcom',
model_name='FWR226e',
model_number='SagemcomFast5290_Frontier',
software_version='SGIt340018_prod',
hardware_version='FWR226e-2.0',
router_name='Frontier1217',
bootloader_version='3.60.2-sec',
product_class='FAST5290',
description='F5290',
additional_hardware_version='2.0',
external_firmware_version='SGIt340018_prod',
internal_firmware_version='v20.2.323',
guiapi_version='1.106',
build_date='2022-11-02T20:00:39-0400',
```