### PR TITLE
Remove need for token based depoyment.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -32,10 +37,8 @@ jobs:
           ref: "main"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and publish to PyPi
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Build package distribution
         run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
           poetry build
-          poetry publish
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request includes several important changes to the GitHub Actions workflow for releases. The changes focus on configuring the environment, updating permissions, and improving the build and publish steps.

### Workflow configuration:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R13-R17): Added the `environment: release` setting to the `deploy` job to specify the environment for the release.

### Permissions:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R13-R17): Added `id-token: write` permission, which is mandatory for trusted publishing.

### Build and publish steps:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-R44): Split the build and publish steps into two separate actions. The build step now only builds the package distribution, and the publish step uses the `pypa/gh-action-pypi-publish@release/v1` action to publish the package distributions to PyPI.