### PR TITLE
Add possibility in example to ignore cert errors and fix the verify_ssl assignment in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ HOST = ""
 USERNAME = ""
 PASSWORD = ""
 ENCRYPTION_METHOD = EncryptionMethod.SHA512 # or EncryptionMethod.MD5
+VALIDATE_SSL_CERT = True
 
 async def main() -> None:
-    async with SagemcomClient(HOST, USERNAME, PASSWORD, ENCRYPTION_METHOD) as client:
+    async with SagemcomClient(HOST, USERNAME, PASSWORD, ENCRYPTION_METHOD, verify_ssl=VALIDATE_SSL_CERT) as client:
         try:
             await client.login()
         except Exception as exception:  # pylint: disable=broad-except

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -105,7 +105,7 @@ class SagemcomClient:
             else ClientSession(
                 headers={"User-Agent": f"{DEFAULT_USER_AGENT}"},
                 timeout=ClientTimeout(DEFAULT_TIMEOUT),
-                connector=TCPConnector(verify_ssl=verify_ssl if verify_ssl else True),
+                connector=TCPConnector(verify_ssl if verify_ssl is not None else True),
             )
         )
 

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -105,7 +105,9 @@ class SagemcomClient:
             else ClientSession(
                 headers={"User-Agent": f"{DEFAULT_USER_AGENT}"},
                 timeout=ClientTimeout(DEFAULT_TIMEOUT),
-                connector=TCPConnector(verify_ssl if verify_ssl is not None else True),
+                connector=TCPConnector(
+                    verify_ssl=verify_ssl if verify_ssl is not None else True
+                ),
             )
         )
 


### PR DESCRIPTION
This addresses #298, adding it explicitly to the example and making it easier for new users to toggle it.
Additionally, the TCPConnector assignment was broken, and this was fixed too. 