### PR TITLE
Handle missing paths in GetDeviceInfo

### DIFF
--- a/sagemcom_api/action_error_exception_handler.py
+++ b/sagemcom_api/action_error_exception_handler.py
@@ -1,0 +1,87 @@
+"""Logic to spot and create ActionErrorExceptions"""
+
+from sagemcom_api.const import (
+    XMO_ACCESS_RESTRICTION_ERR,
+    XMO_AUTHENTICATION_ERR,
+    XMO_LOGIN_RETRY_ERR,
+    XMO_MAX_SESSION_COUNT_ERR,
+    XMO_NON_WRITABLE_PARAMETER_ERR,
+    XMO_NO_ERR,
+    XMO_REQUEST_ACTION_ERR,
+    XMO_UNKNOWN_PATH_ERR
+)
+from sagemcom_api.exceptions import (
+    AccessRestrictionException,
+    AuthenticationException,
+    LoginRetryErrorException,
+    MaximumSessionCountException,
+    NonWritableParameterException,
+    UnknownException,
+    UnknownPathException
+)
+
+
+class ActionErrorHandler:
+    """Raised when a requested action has an error"""
+
+    KNOWN_EXCEPTIONS = (
+        XMO_AUTHENTICATION_ERR,
+        XMO_ACCESS_RESTRICTION_ERR,
+        XMO_NON_WRITABLE_PARAMETER_ERR,
+        XMO_UNKNOWN_PATH_ERR,
+        XMO_MAX_SESSION_COUNT_ERR,
+        XMO_LOGIN_RETRY_ERR
+    )
+
+    @staticmethod
+    def throw_if(response):
+        """For anywhere that needs the old single-exception behaviour"""
+
+        if response["reply"]["error"]["description"] != XMO_REQUEST_ACTION_ERR:
+            return
+
+        actions = response["reply"]["actions"]
+        for action in actions:
+
+            action_error = action["error"]
+            action_error_desc = action_error["description"]
+
+            if action_error_desc == XMO_NO_ERR:
+                continue
+
+            raise ActionErrorHandler.from_error_description(action_error, action_error_desc)
+
+    @staticmethod
+    def is_unknown_exception(desc):
+        """
+        True/false if the ActionError is one of our known types
+        """
+
+        return False if desc == XMO_NO_ERR else desc not in ActionErrorHandler.KNOWN_EXCEPTIONS
+
+    @staticmethod
+    def from_error_description(action_error, action_error_desc):
+        """
+        Create the correct exception from an error, for the caller to throw
+        """
+        # pylint: disable=too-many-return-statements
+
+        if action_error_desc == XMO_AUTHENTICATION_ERR:
+            return AuthenticationException(action_error)
+
+        if action_error_desc == XMO_ACCESS_RESTRICTION_ERR:
+            return AccessRestrictionException(action_error)
+
+        if action_error_desc == XMO_NON_WRITABLE_PARAMETER_ERR:
+            return NonWritableParameterException(action_error)
+
+        if action_error_desc == XMO_UNKNOWN_PATH_ERR:
+            return UnknownPathException(action_error)
+
+        if action_error_desc == XMO_MAX_SESSION_COUNT_ERR:
+            return MaximumSessionCountException(action_error)
+
+        if action_error_desc == XMO_LOGIN_RETRY_ERR:
+            return LoginRetryErrorException(action_error)
+
+        return UnknownException(action_error)

--- a/sagemcom_api/action_error_exception_handler.py
+++ b/sagemcom_api/action_error_exception_handler.py
@@ -1,0 +1,97 @@
+"""Logic to spot and create ActionErrorExceptions."""
+
+from .const import (
+    XMO_ACCESS_RESTRICTION_ERR,
+    XMO_AUTHENTICATION_ERR,
+    XMO_LOGIN_RETRY_ERR,
+    XMO_MAX_SESSION_COUNT_ERR,
+    XMO_NO_ERR,
+    XMO_NON_WRITABLE_PARAMETER_ERR,
+    XMO_REQUEST_ACTION_ERR,
+    XMO_UNKNOWN_PATH_ERR,
+)
+from .exceptions import (
+    AccessRestrictionException,
+    AuthenticationException,
+    LoginRetryErrorException,
+    MaximumSessionCountException,
+    NonWritableParameterException,
+    UnknownException,
+    UnknownPathException,
+)
+
+
+class ActionErrorHandler:
+    """Raised when a requested action has an error."""
+
+    KNOWN_EXCEPTIONS = (
+        XMO_AUTHENTICATION_ERR,
+        XMO_ACCESS_RESTRICTION_ERR,
+        XMO_NON_WRITABLE_PARAMETER_ERR,
+        XMO_UNKNOWN_PATH_ERR,
+        XMO_MAX_SESSION_COUNT_ERR,
+        XMO_LOGIN_RETRY_ERR,
+    )
+
+    @staticmethod
+    def throw_if_error(response, ignore_unknown_path: bool = False) -> None:
+        """Raise the first action-level error, or do nothing if all actions succeeded.
+
+        :param ignore_unknown_path: if True, silently ignore UnknownPathException
+        """
+        if response["reply"]["error"]["description"] != XMO_REQUEST_ACTION_ERR:
+            return
+
+        for action in response["reply"]["actions"]:
+            action_error = action["error"]
+            action_error_desc = action_error["description"]
+            if action_error_desc != XMO_NO_ERR:
+                exc = ActionErrorHandler.from_error_description(action_error, action_error_desc)
+                if ignore_unknown_path and isinstance(exc, UnknownPathException):
+                    continue
+                raise exc
+
+    @staticmethod
+    def throw_if_error_at(response, index: int, ignore_unknown_path: bool = False) -> None:
+        """Raise the error for a specific action, or do nothing if it succeeded.
+
+        :param ignore_unknown_path: if True, silently ignore UnknownPathException
+        """
+        try:
+            action_error = response["reply"]["actions"][index]["error"]
+        except (KeyError, IndexError):
+            return
+
+        action_error_desc = action_error["description"]
+        if action_error_desc == XMO_NO_ERR:
+            return
+
+        exc = ActionErrorHandler.from_error_description(action_error, action_error_desc)
+        if ignore_unknown_path and isinstance(exc, UnknownPathException):
+            return
+        raise exc
+
+    @staticmethod
+    def from_error_description(action_error, action_error_desc):
+        """Create the correct exception from an error, for the caller to throw."""
+        # pylint: disable=too-many-return-statements
+
+        if action_error_desc == XMO_AUTHENTICATION_ERR:
+            return AuthenticationException(action_error)
+
+        if action_error_desc == XMO_ACCESS_RESTRICTION_ERR:
+            return AccessRestrictionException(action_error)
+
+        if action_error_desc == XMO_NON_WRITABLE_PARAMETER_ERR:
+            return NonWritableParameterException(action_error)
+
+        if action_error_desc == XMO_UNKNOWN_PATH_ERR:
+            return UnknownPathException(action_error)
+
+        if action_error_desc == XMO_MAX_SESSION_COUNT_ERR:
+            return MaximumSessionCountException(action_error)
+
+        if action_error_desc == XMO_LOGIN_RETRY_ERR:
+            return LoginRetryErrorException(action_error)
+
+        return UnknownException(action_error)

--- a/sagemcom_api/action_error_exception_handler.py
+++ b/sagemcom_api/action_error_exception_handler.py
@@ -1,6 +1,6 @@
 """Logic to spot and create ActionErrorExceptions."""
 
-from sagemcom_api.const import (
+from .const import (
     XMO_ACCESS_RESTRICTION_ERR,
     XMO_AUTHENTICATION_ERR,
     XMO_LOGIN_RETRY_ERR,
@@ -10,7 +10,7 @@ from sagemcom_api.const import (
     XMO_REQUEST_ACTION_ERR,
     XMO_UNKNOWN_PATH_ERR,
 )
-from sagemcom_api.exceptions import (
+from .exceptions import (
     AccessRestrictionException,
     AuthenticationException,
     LoginRetryErrorException,
@@ -34,25 +34,42 @@ class ActionErrorHandler:
     )
 
     @staticmethod
-    def throw_if(response):
-        """For anywhere that needs the old single-exception behaviour."""
+    def throw_if_error(response, ignore_unknown_path: bool = False) -> None:
+        """Raise the first action-level error, or do nothing if all actions succeeded.
+
+        :param ignore_unknown_path: if True, silently ignore UnknownPathException
+        """
         if response["reply"]["error"]["description"] != XMO_REQUEST_ACTION_ERR:
             return
 
-        actions = response["reply"]["actions"]
-        for action in actions:
+        for action in response["reply"]["actions"]:
             action_error = action["error"]
             action_error_desc = action_error["description"]
-
-            if action_error_desc == XMO_NO_ERR:
-                continue
-
-            raise ActionErrorHandler.from_error_description(action_error, action_error_desc)
+            if action_error_desc != XMO_NO_ERR:
+                exc = ActionErrorHandler.from_error_description(action_error, action_error_desc)
+                if ignore_unknown_path and isinstance(exc, UnknownPathException):
+                    continue
+                raise exc
 
     @staticmethod
-    def is_unknown_exception(desc):
-        """True/false if the ActionError is one of our known types."""
-        return False if desc == XMO_NO_ERR else desc not in ActionErrorHandler.KNOWN_EXCEPTIONS
+    def throw_if_error_at(response, index: int, ignore_unknown_path: bool = False) -> None:
+        """Raise the error for a specific action, or do nothing if it succeeded.
+
+        :param ignore_unknown_path: if True, silently ignore UnknownPathException
+        """
+        try:
+            action_error = response["reply"]["actions"][index]["error"]
+        except (KeyError, IndexError):
+            return
+
+        action_error_desc = action_error["description"]
+        if action_error_desc == XMO_NO_ERR:
+            return
+
+        exc = ActionErrorHandler.from_error_description(action_error, action_error_desc)
+        if ignore_unknown_path and isinstance(exc, UnknownPathException):
+            return
+        raise exc
 
     @staticmethod
     def from_error_description(action_error, action_error_desc):

--- a/sagemcom_api/action_error_exception_handler.py
+++ b/sagemcom_api/action_error_exception_handler.py
@@ -1,14 +1,14 @@
-"""Logic to spot and create ActionErrorExceptions"""
+"""Logic to spot and create ActionErrorExceptions."""
 
 from sagemcom_api.const import (
     XMO_ACCESS_RESTRICTION_ERR,
     XMO_AUTHENTICATION_ERR,
     XMO_LOGIN_RETRY_ERR,
     XMO_MAX_SESSION_COUNT_ERR,
-    XMO_NON_WRITABLE_PARAMETER_ERR,
     XMO_NO_ERR,
+    XMO_NON_WRITABLE_PARAMETER_ERR,
     XMO_REQUEST_ACTION_ERR,
-    XMO_UNKNOWN_PATH_ERR
+    XMO_UNKNOWN_PATH_ERR,
 )
 from sagemcom_api.exceptions import (
     AccessRestrictionException,
@@ -17,12 +17,12 @@ from sagemcom_api.exceptions import (
     MaximumSessionCountException,
     NonWritableParameterException,
     UnknownException,
-    UnknownPathException
+    UnknownPathException,
 )
 
 
 class ActionErrorHandler:
-    """Raised when a requested action has an error"""
+    """Raised when a requested action has an error."""
 
     KNOWN_EXCEPTIONS = (
         XMO_AUTHENTICATION_ERR,
@@ -30,19 +30,17 @@ class ActionErrorHandler:
         XMO_NON_WRITABLE_PARAMETER_ERR,
         XMO_UNKNOWN_PATH_ERR,
         XMO_MAX_SESSION_COUNT_ERR,
-        XMO_LOGIN_RETRY_ERR
+        XMO_LOGIN_RETRY_ERR,
     )
 
     @staticmethod
     def throw_if(response):
-        """For anywhere that needs the old single-exception behaviour"""
-
+        """For anywhere that needs the old single-exception behaviour."""
         if response["reply"]["error"]["description"] != XMO_REQUEST_ACTION_ERR:
             return
 
         actions = response["reply"]["actions"]
         for action in actions:
-
             action_error = action["error"]
             action_error_desc = action_error["description"]
 
@@ -53,17 +51,12 @@ class ActionErrorHandler:
 
     @staticmethod
     def is_unknown_exception(desc):
-        """
-        True/false if the ActionError is one of our known types
-        """
-
+        """True/false if the ActionError is one of our known types."""
         return False if desc == XMO_NO_ERR else desc not in ActionErrorHandler.KNOWN_EXCEPTIONS
 
     @staticmethod
     def from_error_description(action_error, action_error_desc):
-        """
-        Create the correct exception from an error, for the caller to throw
-        """
+        """Create the correct exception from an error, for the caller to throw."""
         # pylint: disable=too-many-return-statements
 
         if action_error_desc == XMO_AUTHENTICATION_ERR:

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -29,7 +29,6 @@ from .const import (
     DEFAULT_USER_AGENT,
     UINT_MAX,
     XMO_INVALID_SESSION_ERR,
-    XMO_NO_ERR,
     XMO_REQUEST_ACTION_ERR,
     XMO_REQUEST_NO_ERR,
 )
@@ -183,19 +182,8 @@ class SagemcomClient:
 
         return value
 
-    def __get_response_value(self, response, index=0, throw_on_action_error: bool = False):
+    def __get_response_value(self, response, index=0):
         """Retrieve response value from value."""
-        if throw_on_action_error:
-            try:
-                error = response["reply"]["actions"][index]["error"]
-            except (KeyError, IndexError):
-                error = None
-
-            if error is not None:
-                error_description = error["description"]
-                if error_description != XMO_NO_ERR:
-                    raise ActionErrorHandler.from_error_description(error, error_description)
-
         try:
             value = self.__get_response(response, index)["value"]
         except KeyError:
@@ -307,12 +295,13 @@ class SagemcomClient:
 
         try:
             response = await self.__api_request_async([actions], True)
-            ActionErrorHandler.throw_if(response)
 
         except TimeoutError as exception:
             raise LoginTimeoutException(
                 "Login request timed-out. This could be caused by using the wrong encryption method, or using a (non) SSL connection."
             ) from exception
+
+        ActionErrorHandler.throw_if_error(response)
 
         data = self.__get_response(response)
 
@@ -328,7 +317,7 @@ class SagemcomClient:
         actions = {"id": 0, "method": "logOut"}
 
         response = await self.__api_request_async([actions], False)
-        ActionErrorHandler.throw_if(response)
+        ActionErrorHandler.throw_if_error(response)
 
         self._session_id = -1
         self._server_nonce = ""
@@ -373,7 +362,7 @@ class SagemcomClient:
         xpath: str,
         options: dict | None = None,
         suppress_action_errors: bool = False,
-    ) -> dict:
+    ) -> Any:
         """Retrieve raw value from router using XPath.
 
         :param xpath: path expression
@@ -387,8 +376,7 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([actions], False)
-        if not suppress_action_errors:
-            ActionErrorHandler.throw_if(response)
+        ActionErrorHandler.throw_if_error(response, ignore_unknown_path=suppress_action_errors)
 
         data = self.__get_response_value(response)
 
@@ -427,10 +415,16 @@ class SagemcomClient:
         ]
 
         response = await self.__api_request_async(actions, False)
-        if not suppress_action_errors:
-            ActionErrorHandler.throw_if(response)
 
-        values = [self.__get_response_value(response, i) for i in range(len(xpaths))]
+        if not suppress_action_errors:
+            ActionErrorHandler.throw_if_error(response)
+            values = [self.__get_response_value(response, i) for i in range(len(xpaths))]
+        else:
+            values = []
+            for i in range(len(xpaths)):
+                ActionErrorHandler.throw_if_error_at(response, i, ignore_unknown_path=True)
+                values.append(self.__get_response_value(response, i))
+
         data = dict(zip(xpaths.keys(), values, strict=True))
 
         return data
@@ -462,7 +456,7 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([actions], False)
-        ActionErrorHandler.throw_if(response)
+        ActionErrorHandler.throw_if_error(response)
 
         return response
 
@@ -492,7 +486,7 @@ class SagemcomClient:
                     "serial_number": "Device/DeviceInfo/SerialNumber",
                     "software_version": "Device/DeviceInfo/SoftwareVersion",
                 },
-                # missing values converted to empty string
+                # missing values returned as None when action errors are suppressed
                 suppress_action_errors=True,
             )
             data["manufacturer"] = "Sagemcom"
@@ -560,7 +554,7 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([action], False)
-        ActionErrorHandler.throw_if(response)
+        ActionErrorHandler.throw_if_error(response)
 
         data = self.__get_response_value(response)
 

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import math
@@ -21,33 +22,25 @@ from aiohttp import (
     ServerDisconnectedError,
     TCPConnector,
 )
+from .action_error_exception_handler import ActionErrorHandler
 
 from .const import (
     API_ENDPOINT,
     DEFAULT_TIMEOUT,
     DEFAULT_USER_AGENT,
     UINT_MAX,
-    XMO_ACCESS_RESTRICTION_ERR,
-    XMO_AUTHENTICATION_ERR,
     XMO_INVALID_SESSION_ERR,
-    XMO_LOGIN_RETRY_ERR,
-    XMO_MAX_SESSION_COUNT_ERR,
     XMO_NO_ERR,
-    XMO_NON_WRITABLE_PARAMETER_ERR,
     XMO_REQUEST_ACTION_ERR,
     XMO_REQUEST_NO_ERR,
-    XMO_UNKNOWN_PATH_ERR,
 )
 from .enums import EncryptionMethod
 from .exceptions import (
-    AccessRestrictionException,
     AuthenticationException,
     BadRequestException,
     InvalidSessionException,
     LoginRetryErrorException,
     LoginTimeoutException,
-    MaximumSessionCountException,
-    NonWritableParameterException,
     UnauthorizedException,
     UnknownException,
     UnknownPathException,
@@ -191,8 +184,19 @@ class SagemcomClient:
 
         return value
 
-    def __get_response_value(self, response, index=0):
+    def __get_response_value(self, response, index=0, throw_on_action_error: bool = False):
         """Retrieve response value from value."""
+        if throw_on_action_error:
+            try:
+                error = response["reply"]["actions"][index]["error"]
+            except (KeyError, IndexError):
+                error = None
+
+            if error is not None:
+                error_description = error["description"]
+                if error_description != XMO_NO_ERR:
+                    raise ActionErrorHandler.from_error_description(error, error_description)
+
         try:
             value = self.__get_response(response, index)["value"]
         except KeyError:
@@ -239,37 +243,10 @@ class SagemcomClient:
                 self._request_id = -1
                 raise InvalidSessionException(error)
 
-            # Error in one of the actions
+            # Unknown error in one of the actions
             if error["description"] == XMO_REQUEST_ACTION_ERR:
-                # pylint:disable=fixme
-                # TODO How to support multiple actions + error handling?
-                actions = result["reply"]["actions"]
-                for action in actions:
-                    action_error = action["error"]
-                    action_error_desc = action_error["description"]
-
-                    if action_error_desc == XMO_NO_ERR:
-                        continue
-
-                    if action_error_desc == XMO_AUTHENTICATION_ERR:
-                        raise AuthenticationException(action_error)
-
-                    if action_error_desc == XMO_ACCESS_RESTRICTION_ERR:
-                        raise AccessRestrictionException(action_error)
-
-                    if action_error_desc == XMO_NON_WRITABLE_PARAMETER_ERR:
-                        raise NonWritableParameterException(action_error)
-
-                    if action_error_desc == XMO_UNKNOWN_PATH_ERR:
-                        raise UnknownPathException(action_error)
-
-                    if action_error_desc == XMO_MAX_SESSION_COUNT_ERR:
-                        raise MaximumSessionCountException(action_error)
-
-                    if action_error_desc == XMO_LOGIN_RETRY_ERR:
-                        raise LoginRetryErrorException(action_error)
-
-                    raise UnknownException(action_error)
+                # leave this to the layer above as there may be multiple actions
+                pass
 
             return result
 
@@ -331,7 +308,9 @@ class SagemcomClient:
 
         try:
             response = await self.__api_request_async([actions], True)
-        except TimeoutError as exception:
+            ActionErrorHandler.throw_if(response)
+
+        except asyncio.TimeoutError as exception:
             raise LoginTimeoutException(
                 "Login request timed-out. This could be caused by using the wrong encryption method, or using a (non) SSL connection."
             ) from exception
@@ -349,7 +328,8 @@ class SagemcomClient:
         """Log out of the Sagemcom F@st device."""
         actions = {"id": 0, "method": "logOut"}
 
-        await self.__api_request_async([actions], False)
+        response = await self.__api_request_async([actions], False)
+        ActionErrorHandler.throw_if(response)
 
         self._session_id = -1
         self._server_nonce = ""
@@ -390,6 +370,12 @@ class SagemcomClient:
         on_backoff=retry_login,
     )
     async def get_value_by_xpath(self, xpath: str, options: dict | None = None) -> dict:
+    async def get_value_by_xpath(
+        self,
+        xpath: str,
+        options: dict | None = None,
+        suppress_action_errors: bool = False,
+    ) -> dict:
         """Retrieve raw value from router using XPath.
 
         :param xpath: path expression
@@ -403,6 +389,9 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([actions], False)
+        if not suppress_action_errors:
+            ActionErrorHandler.throw_if(response)
+
         data = self.__get_response_value(response)
 
         return data
@@ -419,6 +408,12 @@ class SagemcomClient:
         on_backoff=retry_login,
     )
     async def get_values_by_xpaths(self, xpaths, options: dict | None = None) -> dict:
+    async def get_values_by_xpaths(
+        self,
+        xpaths,
+        options: dict | None = None,
+        suppress_action_errors: bool = False,
+    ) -> dict:
         """Retrieve raw values from router using XPath.
 
         :param xpaths: Dict of key to xpath expression
@@ -435,6 +430,9 @@ class SagemcomClient:
         ]
 
         response = await self.__api_request_async(actions, False)
+        if not suppress_action_errors:
+            ActionErrorHandler.throw_if(response)
+
         values = [self.__get_response_value(response, i) for i in range(len(xpaths))]
         data = dict(zip(xpaths.keys(), values, strict=True))
 
@@ -467,6 +465,7 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([actions], False)
+        ActionErrorHandler.throw_if(response)
 
         return response
 
@@ -495,7 +494,9 @@ class SagemcomClient:
                     "product_class": "Device/DeviceInfo/ProductClass",
                     "serial_number": "Device/DeviceInfo/SerialNumber",
                     "software_version": "Device/DeviceInfo/SoftwareVersion",
-                }
+                },
+                # missing values converted to empty string
+                suppress_action_errors=True
             )
             data["manufacturer"] = "Sagemcom"
 
@@ -562,6 +563,8 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([action], False)
+        ActionErrorHandler.throw_if(response)
+
         data = self.__get_response_value(response)
 
         return data

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 import math
@@ -22,8 +21,8 @@ from aiohttp import (
     ServerDisconnectedError,
     TCPConnector,
 )
-from .action_error_exception_handler import ActionErrorHandler
 
+from .action_error_exception_handler import ActionErrorHandler
 from .const import (
     API_ENDPOINT,
     DEFAULT_TIMEOUT,
@@ -310,7 +309,7 @@ class SagemcomClient:
             response = await self.__api_request_async([actions], True)
             ActionErrorHandler.throw_if(response)
 
-        except asyncio.TimeoutError as exception:
+        except TimeoutError as exception:
             raise LoginTimeoutException(
                 "Login request timed-out. This could be caused by using the wrong encryption method, or using a (non) SSL connection."
             ) from exception
@@ -369,7 +368,6 @@ class SagemcomClient:
         max_tries=1,
         on_backoff=retry_login,
     )
-    async def get_value_by_xpath(self, xpath: str, options: dict | None = None) -> dict:
     async def get_value_by_xpath(
         self,
         xpath: str,
@@ -407,7 +405,6 @@ class SagemcomClient:
         max_tries=1,
         on_backoff=retry_login,
     )
-    async def get_values_by_xpaths(self, xpaths, options: dict | None = None) -> dict:
     async def get_values_by_xpaths(
         self,
         xpaths,
@@ -496,7 +493,7 @@ class SagemcomClient:
                     "software_version": "Device/DeviceInfo/SoftwareVersion",
                 },
                 # missing values converted to empty string
-                suppress_action_errors=True
+                suppress_action_errors=True,
             )
             data["manufacturer"] = "Sagemcom"
 

--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -22,33 +22,24 @@ from aiohttp import (
     TCPConnector,
 )
 
+from .action_error_exception_handler import ActionErrorHandler
 from .const import (
     API_ENDPOINT,
     DEFAULT_TIMEOUT,
     DEFAULT_USER_AGENT,
     UINT_MAX,
-    XMO_ACCESS_RESTRICTION_ERR,
-    XMO_AUTHENTICATION_ERR,
     XMO_INVALID_SESSION_ERR,
-    XMO_LOGIN_RETRY_ERR,
-    XMO_MAX_SESSION_COUNT_ERR,
-    XMO_NO_ERR,
-    XMO_NON_WRITABLE_PARAMETER_ERR,
     XMO_REQUEST_ACTION_ERR,
     XMO_REQUEST_NO_ERR,
-    XMO_UNKNOWN_PATH_ERR,
 )
 from .enums import EncryptionMethod
 from .exceptions import (
-    AccessRestrictionException,
     AuthenticationException,
     BadRequestException,
     InvalidSessionException,
     LoginConnectionException,
     LoginRetryErrorException,
     LoginTimeoutException,
-    MaximumSessionCountException,
-    NonWritableParameterException,
     UnauthorizedException,
     UnknownException,
     UnknownPathException,
@@ -240,37 +231,12 @@ class SagemcomClient:
                 self._request_id = -1
                 raise InvalidSessionException(error)
 
-            # Error in one of the actions
+            # Error in one or more of the actions. Leave this to the layer
+            # above (via ActionErrorHandler), since a request may contain
+            # multiple actions and the caller may want to react per-action
+            # (e.g. suppress unknown-path errors for optional values).
             if error["description"] == XMO_REQUEST_ACTION_ERR:
-                # pylint:disable=fixme
-                # TODO How to support multiple actions + error handling?
-                actions = result["reply"]["actions"]
-                for action in actions:
-                    action_error = action["error"]
-                    action_error_desc = action_error["description"]
-
-                    if action_error_desc == XMO_NO_ERR:
-                        continue
-
-                    if action_error_desc == XMO_AUTHENTICATION_ERR:
-                        raise AuthenticationException(action_error)
-
-                    if action_error_desc == XMO_ACCESS_RESTRICTION_ERR:
-                        raise AccessRestrictionException(action_error)
-
-                    if action_error_desc == XMO_NON_WRITABLE_PARAMETER_ERR:
-                        raise NonWritableParameterException(action_error)
-
-                    if action_error_desc == XMO_UNKNOWN_PATH_ERR:
-                        raise UnknownPathException(action_error)
-
-                    if action_error_desc == XMO_MAX_SESSION_COUNT_ERR:
-                        raise MaximumSessionCountException(action_error)
-
-                    if action_error_desc == XMO_LOGIN_RETRY_ERR:
-                        raise LoginRetryErrorException(action_error)
-
-                    raise UnknownException(action_error)
+                pass
 
             return result
 
@@ -339,6 +305,8 @@ class SagemcomClient:
         except (ClientConnectorError, ClientOSError) as exception:
             raise LoginConnectionException("Unable to connect to the device. Please check the host address.") from exception
 
+        ActionErrorHandler.throw_if_error(response)
+
         data = self.__get_response(response)
 
         if data["id"] is not None and data["nonce"] is not None:
@@ -352,7 +320,8 @@ class SagemcomClient:
         """Log out of the Sagemcom F@st device."""
         actions = {"id": 0, "method": "logOut"}
 
-        await self.__api_request_async([actions], False)
+        response = await self.__api_request_async([actions], False)
+        ActionErrorHandler.throw_if_error(response)
 
         self._session_id = -1
         self._server_nonce = ""
@@ -381,13 +350,20 @@ class SagemcomClient:
 
         return None
 
-    async def get_value_by_xpath(self, xpath: str, options: dict | None = None) -> dict:
+    async def get_value_by_xpath(
+        self,
+        xpath: str,
+        options: dict | None = None,
+        suppress_action_errors: bool = False,
+    ) -> Any:
         """Retrieve raw value from router using XPath.
 
         :param xpath: path expression
         :param options: optional options
+        :param suppress_action_errors: if True, return None instead of raising
+            when the path is unknown (other action errors are still raised)
         """
-        result = await self.get_values_by_xpaths({"value": xpath}, options)
+        result = await self.get_values_by_xpaths({"value": xpath}, options, suppress_action_errors)
         return result["value"]
 
     @backoff.on_exception(
@@ -401,11 +377,18 @@ class SagemcomClient:
         max_tries=1,
         on_backoff=retry_login,
     )
-    async def get_values_by_xpaths(self, xpaths: dict[str, str], options: dict | None = None) -> dict:
+    async def get_values_by_xpaths(
+        self,
+        xpaths: dict[str, str],
+        options: dict | None = None,
+        suppress_action_errors: bool = False,
+    ) -> dict:
         """Retrieve raw values from router using XPath.
 
         :param xpaths: Dict of key to xpath expression
         :param options: optional options
+        :param suppress_action_errors: if True, unknown-path actions return None
+            instead of raising, while other action errors are still raised
         """
         actions = [
             {
@@ -418,7 +401,16 @@ class SagemcomClient:
         ]
 
         response = await self.__api_request_async(actions, False)
-        values = [self.__get_response_value(response, i) for i in range(len(xpaths))]
+
+        if not suppress_action_errors:
+            ActionErrorHandler.throw_if_error(response)
+            values = [self.__get_response_value(response, i) for i in range(len(xpaths))]
+        else:
+            values = []
+            for i in range(len(xpaths)):
+                ActionErrorHandler.throw_if_error_at(response, i, ignore_unknown_path=True)
+                values.append(self.__get_response_value(response, i))
+
         data = dict(zip(xpaths.keys(), values, strict=True))
 
         return data
@@ -461,6 +453,8 @@ class SagemcomClient:
         ]
 
         response = await self.__api_request_async(actions, False)
+        ActionErrorHandler.throw_if_error(response)
+
         return response
 
     @backoff.on_exception(
@@ -488,7 +482,9 @@ class SagemcomClient:
                     "product_class": "Device/DeviceInfo/ProductClass",
                     "serial_number": "Device/DeviceInfo/SerialNumber",
                     "software_version": "Device/DeviceInfo/SoftwareVersion",
-                }
+                },
+                # missing values are returned as None when action errors are suppressed
+                suppress_action_errors=True,
             )
             data["manufacturer"] = "Sagemcom"
 
@@ -554,6 +550,8 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([actions], False)
+        ActionErrorHandler.throw_if_error(response)
+
         log_path = response["reply"]["actions"][0]["callbacks"][0]["parameters"]["uri"]
 
         log_uri = f"{self.protocol}://{self.host}{log_path}"
@@ -571,6 +569,8 @@ class SagemcomClient:
         }
 
         response = await self.__api_request_async([action], False)
+        ActionErrorHandler.throw_if_error(response)
+
         data = self.__get_response_value(response)
 
         return data
@@ -585,7 +585,10 @@ class SagemcomClient:
                 "parameters": {"BlockTraffic": block_traffic},
             }
         ]
-        return await self.__api_request_async(actions, False)
+        response = await self.__api_request_async(actions, False)
+        ActionErrorHandler.throw_if_error(response)
+
+        return response
 
     async def get_speed_test_results(self) -> list[SpeedTestResult]:
         """Retrieve Speed Test results from Sagemcom F@st device."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,18 @@ def xpath_value_response() -> dict[str, Any]:
 
 
 @pytest.fixture
+def xpath_unknown_path_error_response() -> dict[str, Any]:
+    """Mock response for XPath query that returns XMO_UNKNOWN_PATH_ERR."""
+    return load_fixture("xpath_unknown_path_error.json")
+
+
+@pytest.fixture
+def xpaths_mixed_errors_response() -> dict[str, Any]:
+    """Mock response for multi-XPath query with one success and one unknown-path error."""
+    return load_fixture("xpaths_mixed_errors.json")
+
+
+@pytest.fixture
 def mock_session_factory():
     """Create a factory for mock aiohttp ClientSession.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,29 @@ def xpath_value_response() -> dict[str, Any]:
 
 
 @pytest.fixture
+def xpath_unknown_path_error_response() -> dict[str, Any]:
+    """Mock response for XPath query that returns XMO_UNKNOWN_PATH_ERR."""
+    return load_fixture("xpath_unknown_path_error.json")
+
+
+@pytest.fixture
+def xpaths_mixed_errors_response() -> dict[str, Any]:
+    """Mock response for multi-XPath query with one success and one unknown-path error."""
+    return load_fixture("xpaths_mixed_errors.json")
+
+
+@pytest.fixture
+def device_info_fallback_partial_response() -> dict[str, Any]:
+    """Mock response for the get_device_info fallback where ModelNumber is unknown.
+
+    Mirrors the TalkTalk F5364 case: individual DeviceInfo attributes are queried
+    after the aggregate Device/DeviceInfo path fails, and ModelNumber returns
+    XMO_UNKNOWN_PATH_ERR while the other attributes succeed.
+    """
+    return load_fixture("device_info_fallback_partial.json")
+
+
+@pytest.fixture
 def mock_session_factory():
     """Create a factory for mock aiohttp ClientSession.
 

--- a/tests/fixtures/device_info_fallback_partial.json
+++ b/tests/fixtures/device_info_fallback_partial.json
@@ -1,0 +1,127 @@
+{
+  "reply": {
+    "uid": 0,
+    "id": 1,
+    "error": {
+      "code": 16777236,
+      "description": "XMO_REQUEST_ACTION_ERR"
+    },
+    "actions": [
+      {
+        "uid": 1,
+        "id": 0,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 1,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/MACAddress",
+            "parameters": {
+              "value": "AA:BB:CC:DD:EE:FF"
+            }
+          }
+        ]
+      },
+      {
+        "uid": 2,
+        "id": 1,
+        "error": {
+          "code": 16777221,
+          "description": "XMO_UNKNOWN_PATH_ERR"
+        },
+        "callbacks": []
+      },
+      {
+        "uid": 3,
+        "id": 2,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 3,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/ProductClass",
+            "parameters": {
+              "value": "F5364"
+            }
+          }
+        ]
+      },
+      {
+        "uid": 4,
+        "id": 3,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 4,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/ProductClass",
+            "parameters": {
+              "value": "F5364"
+            }
+          }
+        ]
+      },
+      {
+        "uid": 5,
+        "id": 4,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 5,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/SerialNumber",
+            "parameters": {
+              "value": "SN123456789"
+            }
+          }
+        ]
+      },
+      {
+        "uid": 6,
+        "id": 5,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 6,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/SoftwareVersion",
+            "parameters": {
+              "value": "1.2.3"
+            }
+          }
+        ]
+      }
+    ],
+    "events": []
+  }
+}

--- a/tests/fixtures/xpath_unknown_path_error.json
+++ b/tests/fixtures/xpath_unknown_path_error.json
@@ -1,0 +1,22 @@
+{
+  "reply": {
+    "uid": 0,
+    "id": 1,
+    "error": {
+      "code": 16777236,
+      "description": "XMO_REQUEST_ACTION_ERR"
+    },
+    "actions": [
+      {
+        "uid": 1,
+        "id": 0,
+        "error": {
+          "code": 16777221,
+          "description": "XMO_UNKNOWN_PATH_ERR"
+        },
+        "callbacks": []
+      }
+    ],
+    "events": []
+  }
+}

--- a/tests/fixtures/xpaths_mixed_errors.json
+++ b/tests/fixtures/xpaths_mixed_errors.json
@@ -1,0 +1,43 @@
+{
+  "reply": {
+    "uid": 0,
+    "id": 1,
+    "error": {
+      "code": 16777236,
+      "description": "XMO_REQUEST_ACTION_ERR"
+    },
+    "actions": [
+      {
+        "uid": 1,
+        "id": 0,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 1,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/MACAddress",
+            "parameters": {
+              "value": "AA:BB:CC:DD:EE:FF"
+            }
+          }
+        ]
+      },
+      {
+        "uid": 2,
+        "id": 1,
+        "error": {
+          "code": 16777221,
+          "description": "XMO_UNKNOWN_PATH_ERR"
+        },
+        "callbacks": []
+      }
+    ],
+    "events": []
+  }
+}

--- a/tests/unit/test_action_error_handler.py
+++ b/tests/unit/test_action_error_handler.py
@@ -1,0 +1,142 @@
+"""Unit tests for ActionErrorHandler."""
+
+import pytest
+
+from sagemcom_api.action_error_exception_handler import ActionErrorHandler
+from sagemcom_api.exceptions import (
+    AccessRestrictionException,
+    AuthenticationException,
+    LoginRetryErrorException,
+    MaximumSessionCountException,
+    NonWritableParameterException,
+    UnknownException,
+    UnknownPathException,
+)
+
+
+def _response(request_desc, action_descs):
+    """Build a minimal JSON-req reply with the given request and action errors."""
+    return {
+        "reply": {
+            "error": {"description": request_desc},
+            "actions": [{"error": {"description": desc}} for desc in action_descs],
+        }
+    }
+
+
+# --- throw_if_error --------------------------------------------------------
+
+
+def test_throw_if_error_noop_when_request_succeeded():
+    """No exception is raised when the request-level error is not an action error."""
+    response = _response("XMO_REQUEST_NO_ERR", ["XMO_UNKNOWN_PATH_ERR"])
+
+    # Must not raise even though an action carries an error description, because
+    # the request-level error indicates overall success.
+    ActionErrorHandler.throw_if_error(response)
+
+
+def test_throw_if_error_noop_when_all_actions_ok():
+    """No exception is raised when every action reports XMO_NO_ERR."""
+    response = _response("XMO_REQUEST_ACTION_ERR", ["XMO_NO_ERR", "XMO_NO_ERR"])
+
+    ActionErrorHandler.throw_if_error(response)
+
+
+def test_throw_if_error_raises_first_action_error():
+    """The first erroring action determines the raised exception."""
+    response = _response(
+        "XMO_REQUEST_ACTION_ERR",
+        ["XMO_NO_ERR", "XMO_UNKNOWN_PATH_ERR", "XMO_AUTHENTICATION_ERR"],
+    )
+
+    with pytest.raises(UnknownPathException):
+        ActionErrorHandler.throw_if_error(response)
+
+
+def test_throw_if_error_ignore_unknown_path_skips_to_next_error():
+    """Unknown-path errors are skipped and a later real error is still raised."""
+    response = _response(
+        "XMO_REQUEST_ACTION_ERR",
+        ["XMO_UNKNOWN_PATH_ERR", "XMO_AUTHENTICATION_ERR"],
+    )
+
+    with pytest.raises(AuthenticationException):
+        ActionErrorHandler.throw_if_error(response, ignore_unknown_path=True)
+
+
+def test_throw_if_error_ignore_unknown_path_noop_when_only_unknown_paths():
+    """A response with only unknown-path errors does not raise when ignoring them."""
+    response = _response(
+        "XMO_REQUEST_ACTION_ERR",
+        ["XMO_UNKNOWN_PATH_ERR", "XMO_UNKNOWN_PATH_ERR"],
+    )
+
+    ActionErrorHandler.throw_if_error(response, ignore_unknown_path=True)
+
+
+# --- throw_if_error_at -----------------------------------------------------
+
+
+def test_throw_if_error_at_raises_for_indexed_action():
+    """The exception for the action at the given index is raised."""
+    response = _response(
+        "XMO_REQUEST_ACTION_ERR",
+        ["XMO_NO_ERR", "XMO_AUTHENTICATION_ERR"],
+    )
+
+    with pytest.raises(AuthenticationException):
+        ActionErrorHandler.throw_if_error_at(response, 1)
+
+
+def test_throw_if_error_at_noop_when_action_ok():
+    """No exception is raised when the indexed action reports XMO_NO_ERR."""
+    response = _response("XMO_REQUEST_ACTION_ERR", ["XMO_NO_ERR"])
+
+    ActionErrorHandler.throw_if_error_at(response, 0)
+
+
+def test_throw_if_error_at_noop_for_out_of_range_index():
+    """An out-of-range index is tolerated rather than raising IndexError."""
+    response = _response("XMO_REQUEST_ACTION_ERR", ["XMO_UNKNOWN_PATH_ERR"])
+
+    ActionErrorHandler.throw_if_error_at(response, 5)
+
+
+def test_throw_if_error_at_ignore_unknown_path():
+    """With ignore_unknown_path, an unknown-path error at the index is tolerated."""
+    response = _response("XMO_REQUEST_ACTION_ERR", ["XMO_UNKNOWN_PATH_ERR"])
+
+    ActionErrorHandler.throw_if_error_at(response, 0, ignore_unknown_path=True)
+
+
+def test_throw_if_error_at_still_raises_non_unknown_path_when_ignoring():
+    """ignore_unknown_path must not suppress other error types."""
+    response = _response("XMO_REQUEST_ACTION_ERR", ["XMO_AUTHENTICATION_ERR"])
+
+    with pytest.raises(AuthenticationException):
+        ActionErrorHandler.throw_if_error_at(response, 0, ignore_unknown_path=True)
+
+
+# --- from_error_description ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("description", "expected"),
+    [
+        ("XMO_AUTHENTICATION_ERR", AuthenticationException),
+        ("XMO_ACCESS_RESTRICTION_ERR", AccessRestrictionException),
+        ("XMO_NON_WRITABLE_PARAMETER_ERR", NonWritableParameterException),
+        ("XMO_UNKNOWN_PATH_ERR", UnknownPathException),
+        ("XMO_MAX_SESSION_COUNT_ERR", MaximumSessionCountException),
+        ("XMO_LOGIN_RETRY_ERR", LoginRetryErrorException),
+        ("SOMETHING_UNEXPECTED", UnknownException),
+    ],
+)
+def test_from_error_description_maps_to_exception(description, expected):
+    """Each known description maps to its exception; anything else is UnknownException."""
+    action_error = {"description": description}
+
+    exc = ActionErrorHandler.from_error_description(action_error, description)
+
+    assert isinstance(exc, expected)

--- a/tests/unit/test_client_basic.py
+++ b/tests/unit/test_client_basic.py
@@ -6,7 +6,7 @@ import pytest
 
 from sagemcom_api.client import SagemcomClient
 from sagemcom_api.enums import EncryptionMethod
-from sagemcom_api.exceptions import AuthenticationException
+from sagemcom_api.exceptions import AuthenticationException, UnknownPathException
 
 
 @pytest.mark.asyncio
@@ -123,3 +123,112 @@ async def test_login_with_preconfigured_fixture(mock_client_sha512):
     assert client.authentication_method == EncryptionMethod.SHA512
     assert client._session_id == 12345
     assert client._server_nonce == "abcdef1234567890"
+
+
+@pytest.mark.asyncio
+async def test_get_value_by_xpath_suppresses_unknown_path(
+    mock_session_factory, login_success_response, xpath_unknown_path_error_response
+):
+    """Test that suppress_action_errors=True returns None for UnknownPathException."""
+    mock_session = mock_session_factory([login_success_response, xpath_unknown_path_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    result = await client.get_value_by_xpath("Device/NonExistent", suppress_action_errors=True)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_value_by_xpath_raises_unknown_path_when_not_suppressed(
+    mock_session_factory, login_success_response, xpath_unknown_path_error_response
+):
+    """Test that suppress_action_errors=False (default) raises UnknownPathException."""
+    mock_session = mock_session_factory([login_success_response, xpath_unknown_path_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    with pytest.raises(UnknownPathException):
+        await client.get_value_by_xpath("Device/NonExistent")
+
+
+@pytest.mark.asyncio
+async def test_get_value_by_xpath_still_raises_auth_error_when_suppressed(
+    mock_session_factory, login_success_response, login_auth_error_response
+):
+    """Test that suppress_action_errors=True still raises AuthenticationException."""
+    mock_session = mock_session_factory([login_success_response, login_auth_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    with pytest.raises(AuthenticationException):
+        await client.get_value_by_xpath("Device/DeviceInfo", suppress_action_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_get_values_by_xpaths_suppresses_unknown_path_per_action(
+    mock_session_factory, login_success_response, xpaths_mixed_errors_response
+):
+    """Test that get_values_by_xpaths with suppress_action_errors=True returns None for
+    unknown-path actions while preserving successful values from other actions."""
+    mock_session = mock_session_factory([login_success_response, xpaths_mixed_errors_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    result = await client.get_values_by_xpaths(
+        {
+            "mac_address": "Device/DeviceInfo/MACAddress",
+            "model_number": "Device/DeviceInfo/ModelNumber",
+        },
+        suppress_action_errors=True,
+    )
+
+    assert result["mac_address"] == "AA:BB:CC:DD:EE:FF"
+    assert result["model_number"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_values_by_xpaths_still_raises_auth_error_when_suppressed(
+    mock_session_factory, login_success_response, login_auth_error_response
+):
+    """Test that get_values_by_xpaths with suppress_action_errors=True still raises
+    AuthenticationException instead of silently swallowing it."""
+    mock_session = mock_session_factory([login_success_response, login_auth_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    with pytest.raises(AuthenticationException):
+        await client.get_values_by_xpaths(
+            {"mac_address": "Device/DeviceInfo/MACAddress"},
+            suppress_action_errors=True,
+        )

--- a/tests/unit/test_client_basic.py
+++ b/tests/unit/test_client_basic.py
@@ -126,9 +126,7 @@ async def test_login_with_preconfigured_fixture(mock_client_sha512):
 
 
 @pytest.mark.asyncio
-async def test_get_value_by_xpath_suppresses_unknown_path(
-    mock_session_factory, login_success_response, xpath_unknown_path_error_response
-):
+async def test_get_value_by_xpath_suppresses_unknown_path(mock_session_factory, login_success_response, xpath_unknown_path_error_response):
     """Test that suppress_action_errors=True returns None for UnknownPathException."""
     mock_session = mock_session_factory([login_success_response, xpath_unknown_path_error_response])
     client = SagemcomClient(
@@ -187,8 +185,10 @@ async def test_get_value_by_xpath_still_raises_auth_error_when_suppressed(
 async def test_get_values_by_xpaths_suppresses_unknown_path_per_action(
     mock_session_factory, login_success_response, xpaths_mixed_errors_response
 ):
-    """Test that get_values_by_xpaths with suppress_action_errors=True returns None for
-    unknown-path actions while preserving successful values from other actions."""
+    """Test per-action suppression of unknown-path errors.
+
+    Unknown-path actions return None while successful values from other actions are preserved.
+    """
     mock_session = mock_session_factory([login_success_response, xpaths_mixed_errors_response])
     client = SagemcomClient(
         host="192.168.1.1",
@@ -215,8 +215,10 @@ async def test_get_values_by_xpaths_suppresses_unknown_path_per_action(
 async def test_get_values_by_xpaths_still_raises_auth_error_when_suppressed(
     mock_session_factory, login_success_response, login_auth_error_response
 ):
-    """Test that get_values_by_xpaths with suppress_action_errors=True still raises
-    AuthenticationException instead of silently swallowing it."""
+    """Test that auth errors still raise even when suppression is enabled.
+
+    Authentication errors must propagate rather than be silently swallowed.
+    """
     mock_session = mock_session_factory([login_success_response, login_auth_error_response])
     client = SagemcomClient(
         host="192.168.1.1",

--- a/tests/unit/test_client_basic.py
+++ b/tests/unit/test_client_basic.py
@@ -6,7 +6,7 @@ import pytest
 
 from sagemcom_api.client import SagemcomClient
 from sagemcom_api.enums import EncryptionMethod
-from sagemcom_api.exceptions import AuthenticationException
+from sagemcom_api.exceptions import AuthenticationException, UnknownPathException
 
 
 @pytest.mark.asyncio
@@ -123,3 +123,147 @@ async def test_login_with_preconfigured_fixture(mock_client_sha512):
     assert client.authentication_method == EncryptionMethod.SHA512
     assert client._session_id == 12345
     assert client._server_nonce == "abcdef1234567890"
+
+
+@pytest.mark.asyncio
+async def test_get_value_by_xpath_suppresses_unknown_path(mock_session_factory, login_success_response, xpath_unknown_path_error_response):
+    """Test that suppress_action_errors=True returns None for UnknownPathException."""
+    mock_session = mock_session_factory([login_success_response, xpath_unknown_path_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    result = await client.get_value_by_xpath("Device/NonExistent", suppress_action_errors=True)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_value_by_xpath_raises_unknown_path_when_not_suppressed(
+    mock_session_factory, login_success_response, xpath_unknown_path_error_response
+):
+    """Test that suppress_action_errors=False (default) raises UnknownPathException."""
+    mock_session = mock_session_factory([login_success_response, xpath_unknown_path_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    with pytest.raises(UnknownPathException):
+        await client.get_value_by_xpath("Device/NonExistent")
+
+
+@pytest.mark.asyncio
+async def test_get_value_by_xpath_still_raises_auth_error_when_suppressed(
+    mock_session_factory, login_success_response, login_auth_error_response
+):
+    """Test that suppress_action_errors=True still raises AuthenticationException."""
+    mock_session = mock_session_factory([login_success_response, login_auth_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    with pytest.raises(AuthenticationException):
+        await client.get_value_by_xpath("Device/DeviceInfo", suppress_action_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_get_values_by_xpaths_suppresses_unknown_path_per_action(
+    mock_session_factory, login_success_response, xpaths_mixed_errors_response
+):
+    """Suppressed unknown-path actions return None while other values are preserved."""
+    mock_session = mock_session_factory([login_success_response, xpaths_mixed_errors_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    result = await client.get_values_by_xpaths(
+        {
+            "mac_address": "Device/DeviceInfo/MACAddress",
+            "model_number": "Device/DeviceInfo/ModelNumber",
+        },
+        suppress_action_errors=True,
+    )
+
+    assert result["mac_address"] == "AA:BB:CC:DD:EE:FF"
+    assert result["model_number"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_values_by_xpaths_still_raises_auth_error_when_suppressed(
+    mock_session_factory, login_success_response, login_auth_error_response
+):
+    """A suppressed call still raises AuthenticationException instead of swallowing it."""
+    mock_session = mock_session_factory([login_success_response, login_auth_error_response])
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    with pytest.raises(AuthenticationException):
+        await client.get_values_by_xpaths(
+            {"mac_address": "Device/DeviceInfo/MACAddress"},
+            suppress_action_errors=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_device_info_falls_back_when_aggregate_path_unknown(
+    mock_session_factory,
+    login_success_response,
+    xpath_unknown_path_error_response,
+    device_info_fallback_partial_response,
+):
+    """A device missing the aggregate DeviceInfo path still yields a DeviceInfo.
+
+    The aggregate probe raises UnknownPathException, triggering the per-attribute
+    fallback. There, the unknown ModelNumber is tolerated (returned as None) while
+    the remaining attributes are populated.
+    """
+    mock_session = mock_session_factory(
+        [
+            login_success_response,
+            xpath_unknown_path_error_response,
+            device_info_fallback_partial_response,
+        ]
+    )
+    client = SagemcomClient(
+        host="192.168.1.1",
+        username="admin",
+        password="admin",
+        authentication_method=EncryptionMethod.MD5,
+        session=mock_session,
+    )
+    await client.login()
+
+    info = await client.get_device_info()
+
+    assert info.mac_address == "AA:BB:CC:DD:EE:FF"
+    assert info.model_name is None  # ModelNumber was unknown, tolerated
+    assert info.model_number == "F5364"
+    assert info.serial_number == "SN123456789"
+    assert info.software_version == "1.2.3"
+    assert info.manufacturer == "Sagemcom"


### PR DESCRIPTION
TalkTalk (UK) branded F5364 does not recognise the ModelNumber attribute requested in GetDeviceInfo
This causes an exception to be thrown, because GetResponse throws for any ActionError.
End result is that HA cant connect to the router to retrieve the useful info, even though the ModelNumber is not essential info.

Fixed by:
 - Lifting behaviour around ActionErrors to higher level, so caller can react appropriately
 - Specifically avoid throwing exceptions on missing path errors when getting DeviceInfo

There was a TODO around how to deal with multiple ActionErrors, which this PR also addresses - since errors can now be thrown at the point of reading the value from the response if required.

For calls other than GetDeviceInfo, the existing behaviour is retained.