### PR TITLE
Allow providing custom ssl context

### DIFF
--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import math
 import random
+from ssl import SSLContext
 from types import TracebackType
 from typing import Any
 import urllib.parse
@@ -78,6 +79,7 @@ class SagemcomClient:
         session: ClientSession | None = None,
         ssl: bool | None = False,
         verify_ssl: bool | None = True,
+        ssl_context: SSLContext | None = None
     ):
         """
         Create a SagemCom client.
@@ -107,7 +109,8 @@ class SagemcomClient:
                 headers={"User-Agent": f"{DEFAULT_USER_AGENT}"},
                 timeout=ClientTimeout(DEFAULT_TIMEOUT),
                 connector=TCPConnector(
-                    verify_ssl=verify_ssl if verify_ssl is not None else True
+                    verify_ssl=verify_ssl,
+                    ssl_context=ssl_context
                 ),
             )
         )


### PR DESCRIPTION
Connecting to my router I got a SSLV3_ALERT_HANDSHAKE_FAILURE. The root cause seems to be an incompatible cipher being used. See 

- https://github.com/iMicknl/python-sagemcom-api/issues/404
- https://stackoverflow.com/a/73254780/487356

This PR allows to create a `SagemcomClient` with a custom SSL context like this:

```
sslcontext = ssl._create_unverified_context()
sslcontext.set_ciphers("AES256-GCM-SHA384")
SagemcomClient(HOST, USERNAME, PASSWORD, ENCRYPTION_METHOD, verify_ssl=None, ssl_context=sslcontext)
```

Note that from a `TCPConnector` perspective, `verify_ssl` and `ssl_context` are mutually exclusive parameters. That's why I had to change the handling of `verify_ssl` slightly, to allow passing in `None`.