### PR TITLE
Disable xpath escape

### DIFF
--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -404,7 +404,7 @@ class SagemcomClient:
         max_tries=1,
         on_backoff=retry_login,
     )
-    async def get_value_by_xpath(self, xpath: str, options: dict | None = None) -> dict:
+    async def get_value_by_xpath(self, xpath: str, options: dict | None = None, escape_xpath: bool | None = True) -> dict:
         """
         Retrieve raw value from router using XPath.
 
@@ -414,7 +414,7 @@ class SagemcomClient:
         actions = {
             "id": 0,
             "method": "getValue",
-            "xpath": urllib.parse.quote(xpath),
+            "xpath": urllib.parse.quote(xpath) if escape_xpath else xpath,
             "options": options if options else {},
         }
 


### PR DESCRIPTION
I had a second problem with my "Sunrise Internet Box".

Attempting to read the value of the following xpath failed:

```
Device/IP/Interfaces/Interface[Alias='IP_DATA']/IPv4Addresses/IPv4Address[Alias='IP_DATA_ADDRESS']/IPAddress
```

Instead of the IP address I was looking for, `get_value_by_xpath` returned a JSON structure with lots of status information in it, but not the IP address I was looking for. Turns out that url quoting messed things up.

So I added a new parameter to the `get_value_by_xpath` function:

The following now returns  the desired IP address as expected:
```
await client.get_value_by_xpath("Device/IP/Interfaces/Interface[Alias='IP_DATA']/IPv4Addresses/IPv4Address[Alias='IP_DATA_ADDRESS']/IPAddress", { "capability-flags": { "interface": True }}, False)
```