### PR TITLE
ci: modernize PR labeler

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,5 +1,0 @@
-feature: ['feature/*', 'feat/*']
-enhancement: enhancement/*
-bug: fix/*
-breaking: breaking/*
-documentation: doc/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,24 @@ categories:
   - title: '📦 Dependencies'
     label: 'dependencies'
 
+autolabeler:
+  - label: 'feature'
+    branch:
+      - '/^feature\//'
+      - '/^feat\//'
+  - label: 'enhancement'
+    branch:
+      - '/^enhancement\//'
+  - label: 'bug'
+    branch:
+      - '/^fix\//'
+  - label: 'breaking'
+    branch:
+      - '/^breaking\//'
+  - label: 'documentation'
+    branch:
+      - '/^doc\//'
+
 template: |
   ## What's changed
   $CHANGES

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,15 +1,17 @@
 name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened]
+
 permissions:
   contents: read
   pull-requests: write
-on:
-  pull_request:
-    types: [opened]
 
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@v5
+      - uses: release-drafter/release-drafter/autolabeler@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- replace TimonVS/pr-labeler-action with Release Drafter's Node 24 autolabeler
- use pull_request_target so labeling works for fork PRs
- preserve the existing branch-to-label conventions exactly
- pin the action to the v7.6.0 commit SHA

This addresses the labeler failure discussed in #505 without checking out or executing contributor-controlled code.

## Verification

- uv run prek run --all-files
- uv run pytest (4 passed)
- git diff --check