### PR TITLE
ci: migrate release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,20 +1,27 @@
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
-exclude-labels:
-  - 'exclude-from-changelog'
 categories:
   - title: '⚠️ Breaking changes'
-    label: 'breaking'
+    when:
+      label: 'breaking'
   - title: '🚀 Features'
-    label: 'feature'
+    when:
+      label: 'feature'
   - title: '✨ Enhancement'
-    label: 'enhancement'
+    when:
+      label: 'enhancement'
   - title: '📘 Documentation'
-    label: 'documentation'
+    when:
+      label: 'documentation'
   - title: '🐛 Bug Fixes'
-    label: 'bug'
+    when:
+      label: 'bug'
   - title: '📦 Dependencies'
-    label: 'dependencies'
+    when:
+      label: 'dependencies'
+  - type: 'pre-exclude'
+    when:
+      label: 'exclude-from-changelog'
 
 autolabeler:
   - label: 'feature'


### PR DESCRIPTION
## Summary

- migrate changelog category labels to `when.label`
- replace deprecated `exclude-labels` with a `pre-exclude` category
- preserve the existing categorization and exclusion behavior

## Validation

- `.venv/bin/prek run check-yaml --files .github/release-drafter.yml`
- `git diff --check`