### PR TITLE
Fix InvalidSessionException treated as permanent auth failure

### DIFF
--- a/sagemcom_api/client.py
+++ b/sagemcom_api/client.py
@@ -403,7 +403,7 @@ class SagemcomClient:
             LoginTimeoutException,
             InvalidSessionException,
         ),
-        max_tries=1,
+        max_tries=2,
         on_backoff=retry_login,
     )
     async def get_values_by_xpaths(self, xpaths: dict[str, str], options: dict | None = None) -> dict:
@@ -445,7 +445,7 @@ class SagemcomClient:
             LoginTimeoutException,
             InvalidSessionException,
         ),
-        max_tries=1,
+        max_tries=2,
         on_backoff=retry_login,
     )
     async def set_values_by_xpaths(self, xpaths: dict[str, str], options: dict | None = None) -> dict:
@@ -476,7 +476,7 @@ class SagemcomClient:
             LoginTimeoutException,
             InvalidSessionException,
         ),
-        max_tries=1,
+        max_tries=2,
         on_backoff=retry_login,
     )
     async def get_device_info(self) -> DeviceInfo:
@@ -507,7 +507,7 @@ class SagemcomClient:
             LoginTimeoutException,
             InvalidSessionException,
         ),
-        max_tries=1,
+        max_tries=2,
         on_backoff=retry_login,
     )
     async def get_hosts(self, only_active: bool | None = False) -> list[Device]:
@@ -529,7 +529,7 @@ class SagemcomClient:
             LoginTimeoutException,
             InvalidSessionException,
         ),
-        max_tries=1,
+        max_tries=2,
         on_backoff=retry_login,
     )
     async def get_port_mappings(self) -> list[PortMapping]:
@@ -547,7 +547,7 @@ class SagemcomClient:
             LoginTimeoutException,
             InvalidSessionException,
         ),
-        max_tries=1,
+        max_tries=2,
         on_backoff=retry_login,
     )
     async def get_logs(self) -> str:

--- a/sagemcom_api/exceptions.py
+++ b/sagemcom_api/exceptions.py
@@ -31,8 +31,13 @@ class AuthenticationException(UnauthorizedException):
     """Raised when authentication is not correct."""
 
 
-class InvalidSessionException(UnauthorizedException):
-    """Raised when session is invalid."""
+class InvalidSessionException(BaseSagemcomException):
+    """Raised when session is invalid.
+
+    This is a transient error that occurs when the router invalidates the
+    session (e.g., due to a concurrent login). It should not be treated as
+    a permanent authorization failure.
+    """
 
 
 class LoginRetryErrorException(BaseSagemcomException):


### PR DESCRIPTION
## Summary

`InvalidSessionException` inherits from `UnauthorizedException`, which causes consumers (like the ha-sagemcom-fast integration) to treat transient session errors as permanent authorization failures.

## Problem

When the router invalidates a session (e.g., due to a concurrent login from the web interface), the API raises `InvalidSessionException`. Because it inherits from `UnauthorizedException`, consumers that catch `UnauthorizedException` to detect permanent auth failures (like Home Assistant raising `ConfigEntryAuthFailed`) incorrectly treat this transient condition as "bad credentials", permanently disabling the integration.

Additionally, `max_tries=1` on the backoff decorators means the `on_backoff=retry_login` handler fires but no actual retry occurs — the function is only called once.

## Fix

1. **Change exception hierarchy**: `InvalidSessionException` now inherits from `BaseSagemcomException` instead of `UnauthorizedException`. This is a transient error, not a permanent auth failure.

2. **Increase `max_tries` to 2**: With `max_tries=2`, when an `InvalidSessionException` occurs, the backoff handler calls `retry_login()` and then retries the operation once before giving up.

## Breaking Change Note

This is a **minor breaking change** for consumers that catch `UnauthorizedException` and expect `InvalidSessionException` to be included. Consumers should update to catch `InvalidSessionException` separately if they need to handle it. The ha-sagemcom-fast integration already has a [PR to handle this](https://github.com/iMicknl/ha-sagemcom-fast/pull/273).

## Reproduction

1. Log in to the router web interface during an API poll cycle
2. The concurrent login invalidates the library's session
3. `get_hosts()` raises `InvalidSessionException`
4. Consumer catches it as `UnauthorizedException` → permanent failure

After this fix, the library retries the login and operation automatically.